### PR TITLE
Remove stray apostrophe after last fix

### DIFF
--- a/notes/oc/extract-infrastructure-id.md
+++ b/notes/oc/extract-infrastructure-id.md
@@ -16,6 +16,6 @@ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ### Extract Infrastructure ID (infraID) from $install_dir
 
 ```
-jq -r '."*installconfig.ClusterID".InfraID' .openshift_install_state.json'
+jq -r '."*installconfig.ClusterID".InfraID' .openshift_install_state.json
 jq -r .infraID metadata.json
 ```


### PR DESCRIPTION
The last fix (88795778b4f237381a4fcead73452200ad58b725) to this command failed to remove the apostrophe at the end of the line.